### PR TITLE
Shave off extra allocation for haskell

### DIFF
--- a/src/haskell/cat.hs
+++ b/src/haskell/cat.hs
@@ -1,14 +1,15 @@
 import System.IO
-import qualified Data.ByteString as BS
+import Foreign.Marshal.Alloc (allocaBytes)
 
 main = do
-    withBinaryFile "../data" ReadMode $ \handle -> do
-        let bufSize = 2 ^ 17
-            go = do
-                block <- BS.hGet handle bufSize
-                BS.hPut stdout block
-                if BS.null block
+    withBinaryFile "../data" ReadMode $ \handle ->
+      allocaBytes bufSize $ \buf -> do
+        let go = do
+              n <- hGetBuf handle buf bufSize
+              hPutBuf stdout buf n
+              if n < bufSize
                 then pure ()
                 else go
-        hSetBuffering handle $ BlockBuffering (Just bufSize)
+        hSetBuffering handle $ NoBuffering
         go
+  where bufSize = 2 ^ 17


### PR DESCRIPTION
`Data.ByteString.hGet` uses `hGetBuf` internally anyway, but allocates a new buffer on every call. It's better to reuse the same buffer.
Also disabled buffering (seems to work slightly faster for me).
Overall this version works about 8% faster on my machine.
