### PR TITLE
Improving performance for Java through nio and for Racket through command-line args.

### DIFF
--- a/src/java/cat.java
+++ b/src/java/cat.java
@@ -1,13 +1,32 @@
-import java.io.IOException;
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
 
 class Cat {
+    private static final long BLOCK_SIZE = 131072;
+
+    private static void copyFile( File from, File to ) throws IOException {
+
+        if ( !to.exists() ) { to.createNewFile(); }
+
+        try (
+                FileChannel in = new FileInputStream( from ).getChannel();
+                FileChannel out = new FileOutputStream( to ).getChannel()
+        ) {
+            long start = 0;
+            long transferred = 0;
+            do {
+                transferred = out.transferFrom(in, start, BLOCK_SIZE);
+                start += transferred;
+            } while (transferred > 0);
+        }
+    }
+
     public static void main(String[] args) throws IOException {
-      byte[] buffer = new byte[131072];
-      FileInputStream in = new FileInputStream("../data");      
-      int n = 0;
-      while ((n = in.read(buffer)) != -1) {
-	System.out.write(buffer, 0, n);
-      }
+        final File data = new File("../data");
+        final File stdout = new File("/dev/stdout");
+        copyFile(data, stdout);
     }
 }

--- a/src/racket/Makefile
+++ b/src/racket/Makefile
@@ -1,5 +1,5 @@
 all:
 test:
-	./cat.scm ../data > /dev/null
+	racket -q -r cat.rkt ../data > /dev/null
 version:
 	racket --version > version

--- a/src/racket/cat.rkt
+++ b/src/racket/cat.rkt
@@ -1,14 +1,11 @@
 #lang racket/base
+(require racket/port)
 
 (define buffer-size 131072)
 
 (define (main)
   (call-with-input-file "../data"
     (lambda (input-port)
-      (let loop ((x (read-bytes buffer-size input-port)))
-	(when (not (eof-object? x))
-	      (begin
-		(display x)
-		(loop (read-bytes buffer-size input-port))))))))
+      (copy-port input-port current-output-port))))
 
 (main)

--- a/src/racket/cat.rkt
+++ b/src/racket/cat.rkt
@@ -1,4 +1,4 @@
-#!/usr/bin/racket -f
+#lang racket/base
 
 (define buffer-size 131072)
 


### PR DESCRIPTION
Java `nio` package is known to be more performant than Java Streams (`io` package).
My local benchmark shows orders of magnitude performance increase.
