### PR TITLE
Fix to Racket implementation + compilation.

### DIFF
--- a/src/racket/Makefile
+++ b/src/racket/Makefile
@@ -1,5 +1,6 @@
 all:
+	raco exe cat.rkt
 test:
-	racket -q -r cat.rkt ../data > /dev/null
+	./cat >/dev/null
 version:
 	racket --version > version

--- a/src/racket/cat.rkt
+++ b/src/racket/cat.rkt
@@ -4,8 +4,9 @@
 (define buffer-size 131072)
 
 (define (main)
+  (display "Running...\n")
   (call-with-input-file "../data"
     (lambda (input-port)
-      (copy-port input-port current-output-port))))
+      (copy-port input-port (current-output-port)))))
 
 (main)


### PR DESCRIPTION
There was a stupid error which caused Racket to do nothing which it does blazingly fast. Now it actually does copy data.
I've added compilation/executable generation step but it doesn't really increase performance.
